### PR TITLE
Upgrade Web3 Dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "ethpm-spec"]
 	path = ethpm-spec
 	url = https://github.com/ethpm/ethpm-spec.git
-[submodule "rust-web3"]
-	path = rust-web3
-	url = https://github.com/tomusdrw/rust-web3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde-json-core = { version = "0.0.1", optional = true }
 
 [dev-dependencies]
 paste = "0.1"
-web3 = { path = "rust-web3/", version = "0.7.0" }
+web3 = "0.8.0"
 assert_cmd = "0.10"
 tempfile = "3.1.0"
 


### PR DESCRIPTION
The `web3` library is on crates.io, so decided to remove the explicit submodule and upgrade to the latest version.