### PR TITLE
`extern crate ...` no longer needed since rustc 1.31

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -3,12 +3,8 @@
 //!
 
 #[cfg(all(feature = "no-std", not(test)))]
-extern crate alloc;
-
-#[cfg(all(feature = "no-std", not(test)))]
 use alloc::vec::Vec;
 
-extern crate serde;
 use serde::{Deserialize, Serialize};
 
 use crate::documentation::{CompilerInformation, NatSpec, LinkValue, LinkReference}; 

--- a/src/documentation.rs
+++ b/src/documentation.rs
@@ -3,9 +3,6 @@
 //!
 
 #[cfg(all(feature = "no-std", not(test)))]
-extern crate alloc;
-
-#[cfg(all(feature = "no-std", not(test)))]
 use alloc::vec::Vec;
 
 #[cfg(all(feature = "no-std", not(test)))]
@@ -13,7 +10,6 @@ use alloc::collections::btree_map::BTreeMap;
 #[cfg(any(feature = "default", feature = "std", test))]
 use std::collections::BTreeMap;
 
-extern crate serde;
 use serde::{Deserialize, Serialize};
 
 use crate::contract::EthValueType;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,17 +5,6 @@
 #[cfg(all(feature = "no-std", not(test)))]
 #[no_std]
 
-#[cfg(any(feature = "default", feature = "std", test))]
-#[macro_use]
-extern crate std;
-
-#[cfg(all(feature = "no-std", not(test)))]
-#[macro_use]
-extern crate core as std;
-
-#[cfg(all(feature = "no-std", not(test)))]
-extern crate alloc;
-
 #[cfg(all(feature = "no-std", not(test)))]
 use alloc::vec::Vec;
 
@@ -23,12 +12,6 @@ use alloc::vec::Vec;
 use alloc::collections::btree_map::BTreeMap;
 #[cfg(any(feature = "default", feature = "std", test))]
 use std::collections::BTreeMap;
-
-extern crate serde;
-#[cfg(any(feature = "default", feature = "std", test))]
-extern crate serde_json;
-#[cfg(all(feature = "no-std", not(test)))]
-extern crate serde_json_core;
 
 use serde::{Deserialize, Serialize};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,5 @@
-extern crate ethpm;
 use ethpm::Package;
 
-extern crate clap;
 use clap::{Arg, ArgMatches, App};
 
 use std::fs;

--- a/tests/spec_examples.rs
+++ b/tests/spec_examples.rs
@@ -1,8 +1,6 @@
 use std::fs;
 use std::io::prelude::*;
 
-extern crate paste;
-
 use ::ethpm::Package;
 
 macro_rules! test_case {


### PR DESCRIPTION
So I removed it from the codebase